### PR TITLE
Prevent 'reset device after Wi-Fi change' dialog when there is no Wi-Fi

### DIFF
--- a/endaqconfig/config_dialog.py
+++ b/endaqconfig/config_dialog.py
@@ -501,7 +501,7 @@ class ConfigDialog(SC.SizedDialog):
         self._saveTabs()
         self._setClock()
 
-        if self.configData.get(0x18ff7f) != wifiWasEnabled:
+        if self.device.hasWifi and self.configData.get(0x18ff7f) != wifiWasEnabled:
             q = wx.MessageBox("Reset recording device?\n\n"
                               "Enabling or disabling Wi-Fi requires the "
                               "recording device to reset in order to take effect.\n"


### PR DESCRIPTION
The dialog prompting to reset the device after changing Wi-Fi was showing up on STM32 devices without Wi-Fi (something slightly different in the CONFIG.UI?). It revealed the conditional wasn't quite right.