### PR TITLE
ES-623 ES-635 'Apply Wi-Fi' tweaks

### DIFF
--- a/endaqconfig/config_dialog.py
+++ b/endaqconfig/config_dialog.py
@@ -85,12 +85,12 @@ class ConfigDialog(SC.SizedDialog):
         """
         self.schema = loadSchema('mide_config_ui.xml')
 
-        self.setTime = kwargs.pop('setTime', True)
-        self.device = kwargs.pop('device', None)
-        self.saveOnOk = kwargs.pop('saveOnOk', True)
-        self.useUtc = kwargs.pop('useUtc', True)
-        self.showAdvanced = kwargs.pop('showAdvanced', False)
-        self.DEBUG = kwargs.pop('debug', __DEBUG__)
+        self.setTime: bool = kwargs.pop('setTime', True)
+        self.device: Optional[endaq.device.Recorder] = kwargs.pop('device', None)
+        self.saveOnOk: bool = kwargs.pop('saveOnOk', True)
+        self.useUtc: bool = kwargs.pop('useUtc', True)
+        self.showAdvanced: bool = kwargs.pop('showAdvanced', False)
+        self.DEBUG: bool = kwargs.pop('debug', __DEBUG__)
         icon = kwargs.pop('icon', None)
 
         self.postConfigMessage = None
@@ -146,17 +146,15 @@ class ConfigDialog(SC.SizedDialog):
         check_box_sizer.SetSizerType("horizontal")
         check_box_sizer.SetSizerProps(expand=True)
 
-        # Restore the following if/when import and export are fixed.
         self.setClockCheck = wx.CheckBox(check_box_sizer, -1, "Set device clock on exit")
         self.setClockCheck.SetSizerProps(expand=True, border=(['top', 'bottom'], 8))
 
         SC.SizedPanel(check_box_sizer, -1).SetSizerProps(proportion=1)  # Spacer
 
-        if self.device.__class__.__name__ == 'EndaqW':
+        if self.device.hasWifi:
             self.applyWifiChangesCheck = wx.CheckBox(check_box_sizer, -1, "Apply WiFi changes on exit")
             self.applyWifiChangesCheck.SetSizerProps(halign='right', expand=True, border=(['top', 'bottom'], 8))
-
-            self.applyWifiChangesCheck.SetValue(True)
+            # self.applyWifiChangesCheck.SetValue(True)
         else:
             self.applyWifiChangesCheck = None
 
@@ -164,7 +162,6 @@ class ConfigDialog(SC.SizedDialog):
         buttonpane.SetSizerType("horizontal")
         buttonpane.SetSizerProps(expand=True)  # , border=(['top'], 8))
 
-        # Restore the following if/when import and export are fixed.
         self.importBtn = wx.Button(buttonpane, -1, "Import...")
         self.exportBtn = wx.Button(buttonpane, -1, "Export...")
 
@@ -178,12 +175,6 @@ class ConfigDialog(SC.SizedDialog):
 
         self.exportBtn.SetToolTip(exportTT)
         self.importBtn.SetToolTip(importTT)
-
-        # Remove the following if/when import and export are fixed.
-        # This puts the 'set clock' checkbox in line with the OK/Cancel
-        # buttons, where Import/Export used to be.
-        #         self.setClockCheck = wx.CheckBox(buttonpane, -1, "Set device clock on exit")
-        #         self.setClockCheck.SetSizerProps(expand=True, border=(['top', 'bottom'], 8))
 
         SC.SizedPanel(buttonpane, -1).SetSizerProps(proportion=1)  # Spacer
         wx.Button(buttonpane, wx.ID_OK)
@@ -210,8 +201,6 @@ class ConfigDialog(SC.SizedDialog):
     def buildUI(self):
         """ Construct and populate the UI based on the ConfigUI element.
         """
-        rootEl = []
-
         try:
             rootEl = self.hints[0]
         except IndexError:
@@ -587,6 +576,7 @@ def configureRecorder(path: Union[str, endaq.device.Recorder],
         :param exceptions: If `True`, allow all exceptions to be raised. If
             `False`, show descriptive message boxes when anticipated errors
              occur, intended for standalong use.
+        :param debug: If `True`, show/log debugging messages.
         :return: `None` if configuration was cancelled, else a tuple
             containing:
                 * The data written to the recorder (a nested dictionary)

--- a/endaqconfig/config_dialog.py
+++ b/endaqconfig/config_dialog.py
@@ -152,7 +152,7 @@ class ConfigDialog(SC.SizedDialog):
         SC.SizedPanel(check_box_sizer, -1).SetSizerProps(proportion=1)  # Spacer
 
         if self.device.hasWifi:
-            self.applyWifiChangesCheck = wx.CheckBox(check_box_sizer, -1, "Apply WiFi changes on exit")
+            self.applyWifiChangesCheck = wx.CheckBox(check_box_sizer, -1, "Apply Wi-Fi changes on exit")
             self.applyWifiChangesCheck.SetSizerProps(halign='right', expand=True, border=(['top', 'bottom'], 8))
             # self.applyWifiChangesCheck.SetValue(True)
         else:

--- a/endaqconfig/wifi_tab.py
+++ b/endaqconfig/wifi_tab.py
@@ -138,7 +138,7 @@ class ContinousNetworkStatusChecker(threading.Thread):
                 if bool(self.parent):
                     wx.PostEvent(self.parent, evt)
 
-            except DeviceTimeout as E:
+            except DeviceTimeout:
                 logger.warning("Timed out when checking the network connection, retrying")
 
             except DeviceError as E:
@@ -291,15 +291,12 @@ class WiFiSelectionTab(Tab):
             integrated with the rest of the tabs.
         """
         self.info = []
-
+        self.parent = kwargs['root']
         self.device = kwargs['root'].device
 
         super(WiFiSelectionTab, self).__init__(*args, **kwargs)
 
-        self.parent = kwargs['root']
-
         self.networkStatusThread = ContinousNetworkStatusChecker(self)
-
         self.networkStatusThread.start()
 
 
@@ -324,7 +321,7 @@ class WiFiSelectionTab(Tab):
         self.list = self.WifiListCtrl(self, -1,
                                       style=(wx.LC_REPORT | wx.BORDER_SUNKEN | wx.LC_SORT_ASCENDING |
                                              wx.LC_VRULES | wx.LC_HRULES | wx.LC_SINGLE_SEL))
-
+        # self.list.EnableCheckBoxes()
         sizer.Add(self.list, 1, wx.EXPAND | wx.ALL, 8)
 
         self.list.setResizeColumn(0)
@@ -338,7 +335,6 @@ class WiFiSelectionTab(Tab):
         self.list.SetColumnWidth(0, wx.LIST_AUTOSIZE)
 
         self.list.InsertColumn(1, self.COLUMNS[1], width=wx.LIST_AUTOSIZE)
-
         self.list.InsertColumn(2, self.COLUMNS[2], width=wx.LIST_AUTOSIZE)
 
         self.listFont = self.list.GetFont()
@@ -368,7 +364,7 @@ class WiFiSelectionTab(Tab):
         self.pwField.Enable(False)
 
         pwstyle = wx.RESERVE_SPACE_EVEN_IF_HIDDEN
-        pwsizer.AddMany(((self.pwCheck, 0, pwstyle),
+        pwsizer.AddMany(((self.pwCheck, 0, pwstyle | wx.ALIGN_CENTER_VERTICAL),
                          (self.pwField, 1, pwstyle | wx.EXPAND)))
         sizer.Add(pwsizer, 0, wx.EXPAND | wx.ALL, 8)
 
@@ -588,7 +584,7 @@ class WiFiSelectionTab(Tab):
         enable = False
 
         # Check for changes of selected AP
-        if self.firstSelected == -1 or self.selected != self.firstSelected:
+        if self.selected != self.firstSelected:
             enable = True
         elif self.info[self.firstSelected]['SSID'] in self.passwords:
             enable = True


### PR DESCRIPTION
This partially addresses issues ES-623("'Apply WiFi changes on exit' check badly implemented") and ES-635 ("'Apply WiFi changes on exit' can disconnect device from AP"):
* The appearance of the 'Apply WiFi changes on exit' checkbox no longer based on Recorder subclass name.
* The Wi-Fi tab's 'Apply' button correctly disabled on start.
* The 'Apply Wi-Fi changes on exit' no longer checked by default.
Also included are some visual and code cleanup.

This is not a complete solution to ES-635, but it works around the primary issue. The Wi-Fi tab needs a bit of a redesign. More substantial improvements can be made then.