### PR TITLE
Config export fix, 'uploading' state display

### DIFF
--- a/endaqconfig/config_dialog.py
+++ b/endaqconfig/config_dialog.py
@@ -34,7 +34,7 @@ import wx.lib.sized_controls as SC
 
 from ebmlite import loadSchema
 import endaq.device
-from endaq.device import Recorder, configio
+from endaq.device import Recorder, configio, ConfigError
 
 from .base import logger
 from . import base
@@ -420,13 +420,17 @@ class ConfigDialog(SC.SizedDialog):
                     self.updateDeviceConfig()
                     configio.exportConfig(self.device, dlg.GetPath())
 
+                except ConfigError as err:
+                    self.showError(str(err), "Configuration Export Failed",
+                                   style=wx.OK | wx.ICON_EXCLAMATION)
+
                 except Exception as err:
                     # TODO: More specific error message
                     logger.error('Could not export configuration ({}: {})'
                                  .format(type(err).__name__, err))
                     self.showError(
                             "The configuration data could not be exported to the "
-                            "specified file.", "Config Export Failed",
+                            "specified file.", "Configuration Export Failed",
                             style=wx.OK | wx.ICON_EXCLAMATION)
 
 

--- a/endaqconfig/special_tabs.py
+++ b/endaqconfig/special_tabs.py
@@ -97,6 +97,10 @@ class InfoPanel(HtmlWindow):
                    'FwRev': 'Firmware Revision',
                    'McuType': 'MCU Type',
                    'FwRevStr': 'Firmware Version',
+                   'SerialCommandInterface': 'Has Serial Command Interface',
+                   'FileCommandInterface': 'Has File Command Interface',
+                   'HasEsp32': 'Has ESP32 Wi-Fi',
+                   'NcpAppFwVer': 'Network Interface FW Version',
                    }
 
     # Formatters for specific fields. The keys should be the string as
@@ -108,8 +112,14 @@ class InfoPanel(HtmlWindow):
                    'Recorder Serial': str,
                    'Calibration Date': str,
                    'Calibration Expiration Date': str,
-                   'Calibration Serial Number': lambda x: "C%05d" % x
+                   'Calibration Serial Number': lambda x: "C%05d" % x,
+                   'Has File Command Interface': lambda x: bool(x),
+                   'Has Serial Command Interface': lambda x: 'True',
+                   'Has ESP32 Wi-Fi': lambda x: 'True',
+                   'Network Interface FW Version': str,
                    }
+
+    excluded_fields = ('RecorderTypeUID', 'WispiApiLevel',)
 
     column_widths = (50, 50)
 
@@ -201,7 +211,7 @@ class InfoPanel(HtmlWindow):
 
         items = []
         for k, v in self.info.items():
-            if str(k).startswith('Unknown'):
+            if k in self.excluded_fields or str(k).startswith('Unknown'):
                 continue
 
             items.append((self.field_names.get(k, self._fromCamelCase(k)), v))

--- a/endaqconfig/widgets/device_dialog.py
+++ b/endaqconfig/widgets/device_dialog.py
@@ -449,7 +449,8 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
         20: wx.YELLOW,  # Reset pending
         30: wx.YELLOW,  # Start Pending
         40: wx.YELLOW,  # Triggering
-        50: wx.Colour(200, 200, 200),  # Sleeping
+        50: wx.BLUE,  # Uploading
+        100: wx.Colour(200, 200, 200),  # Sleeping
         -10: wx.RED  # Error (default for all negative status codes)
     }
 
@@ -461,7 +462,8 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
         20: "Resetting",
         30: "Starting Recording",
         40: "Awaiting Trigger",
-        50: "Sleeping",
+        50: "Uploading",
+        100: "Sleeping",
         -10: "Error"
     }
 
@@ -714,17 +716,20 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
         if dev.available:
             return self.ICON_CONNECTION_MSD
 
-        # This is a primitive mechanism based on the `ConfigInterface`
-        # subclass name. Also, all but USB are currently hypothetical.
-        configname = dev.command.__class__.__name__.lower()
-        if 'serial' in configname:
-            return self.ICON_CONNECTION_USB
-        elif 'mqtt' in configname:
-            return self.ICON_CONNECTION_WIFI
-        elif any(n in configname for n in ('bluetooth', 'bt', 'ble')):
-            return self.ICON_CONNECTION_BT
-        else:
-            return self.ICON_NONE
+        try:
+            # This is a primitive mechanism based on the `ConfigInterface`
+            # subclass name. Also, all but USB are currently hypothetical.
+            configname = dev.command.__class__.__name__.lower()
+            if 'serial' in configname:
+                return self.ICON_CONNECTION_USB
+            elif 'mqtt' in configname:
+                return self.ICON_CONNECTION_WIFI
+            elif any(n in configname for n in ('bluetooth', 'bt', 'ble')):
+                return self.ICON_CONNECTION_BT
+        except (AttributeError, NotImplementedError, UnsupportedFeature):
+            pass
+
+        return self.ICON_NONE
 
 
     def setItemIcon(self, index, dev):


### PR DESCRIPTION
Fixed error when exporting with no config data; added display of device in Uploading state; fixed edge case issue with connection icon; cleaned up info tab. Goes with https://github.com/MideTechnology/endaq-device/pull/101.