### PR TITLE
Feature/es 646 device dialog cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ enDAQ&trade; Data Recorder Configuration GUI
 ============================================
 
 This is a Python script is a standalone version of the configuration dialog in enDAQ Lab, for performing 
-configuration of enDAQ (and legacy SlamStick X, C, and S) data recorders via a user-friendly GUI. It can
+configuration of enDAQ™ (and legacy SlamStick™ X, C, and S) data recorders via a user-friendly GUI. It can
 also be imported in another script for device selection and/or configuration.
 
 Python 3.9 or later required. It is known to work in Windows 10 and up; it *may* work in Linux and

--- a/endaqconfig/config_dialog.py
+++ b/endaqconfig/config_dialog.py
@@ -514,7 +514,8 @@ class ConfigDialog(SC.SizedDialog):
         """ Handle dialog cancel, prompting the user to save any changes.
         """
         if self.configChanged():
-            q = self.showError("Save configuration changes before exiting?",
+            q = self.showError("Save configuration changes before exiting?\n\n"
+                               '"No" will discard changes.',
                                "Configure Device",
                                style=(wx.YES_NO | wx.CANCEL | wx.CANCEL_DEFAULT
                                       | wx.ICON_QUESTION))

--- a/endaqconfig/widgets/controls.py
+++ b/endaqconfig/widgets/controls.py
@@ -52,6 +52,7 @@ class ControlButtons(wx.Panel):
         self.column = column
 
         self.recording = False
+        self.uploading = False
 
         bg = parent.GetBackgroundColour()
         self.SetBackgroundColour(bg)
@@ -88,17 +89,25 @@ class ControlButtons(wx.Panel):
     def updateButtons(self, enabled=True):
         """ Update the button labels, tooltips, and enabled/disabled state.
         """
-        self.recBtn.Enable(enabled and self.device.canRecord)
-        self.configBtn.Enable(enabled
-                              and self.device.hasConfigInterface
-                              and self.device.config.available)
-
         try:
             status = self.device.command.status[0]
         except (AttributeError, CommandError, UnsupportedFeature):
             status = None
 
         self.recording = status == DeviceStatusCode.RECORDING
+        self.uploading = status == DeviceStatusCode.UPLOADING
+
+
+        self.recBtn.Show(self.device.canRecord)
+        self.recBtn.Enable(enabled
+                           and self.device.canRecord
+                           and not self.uploading)
+
+        self.configBtn.Enable(enabled
+                              and self.device.hasConfigInterface
+                              and self.device.config.available
+                              and not self.uploading
+                              and not self.recording)
 
         if self.recording:
             self.recBtn.SetLabel("Stop Recording")

--- a/endaqconfig/widgets/device_dialog.py
+++ b/endaqconfig/widgets/device_dialog.py
@@ -440,7 +440,7 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
     # Tool tips for the 'record' button
     RECORD_UNSELECTED = "No recorder selected"
     RECORD_UNSUPPORTED = "Device does not support recording via software"
-    RECORD_ENABLED = "Initiate recording on the selected device"
+    RECORD_ENABLED = "Initiate recording on all capable devices"
 
     # Text colors for the Status column
     STATUS_COLORS = {
@@ -527,7 +527,7 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
 
         self.autoUpdate = kwargs.pop('autoUpdate', 500)
         self.hideClock = kwargs.pop('hideClock', False)
-        self.hideRecord = kwargs.pop('hideRecord', False)
+        self.hideRecord = kwargs.pop('hideRecord', True)
         self.showWarnings = kwargs.pop('showWarnings', True)
         self.showConnection = kwargs.pop('showConnection', True)
         self.showAdvanced = kwargs.pop('showAdvanced', False)
@@ -581,10 +581,10 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
         self.setClockButton.Show(not self.hideClock)
 
         self.recordButton = wx.Button(buttonpane, self.ID_START_RECORDING,
-                                      "Start Recording")
+                                      "Start All Recorders")
         self.recordButton.SetSizerProps(halign="left")
         self.recordButton.SetToolTip(self.RECORD_ENABLED)
-        self.Bind(wx.EVT_BUTTON, self.OnStartRecording, id=self.ID_START_RECORDING)
+        self.Bind(wx.EVT_BUTTON, self.OnStartAllRecorders, id=self.ID_START_RECORDING)
         self.recordButton.Enable(False)
         self.recordButton.Show(not self.hideRecord)
 
@@ -1181,6 +1181,18 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
         finally:
             if self.thread and self.thread.is_alive():
                 self.thread.resume()
+
+
+    def OnStartAllRecorders(self,
+                            evt: Union[wx.CommandEvent, EvtRecordButton, None] = None):
+        """ Send the 'start recording' command to all devices.
+
+            This is placeholder for future functionality. It may or may not
+            ever be implemented.
+        """
+        # If/when this is implemented, it will be like `OnSetClocks()`
+        logger.warning("OnStartAllRecorders() is not implemented (yet)!")
+        evt.Skip()
 
 
     def OnDeviceListUpdate(self, evt):

--- a/endaqconfig/widgets/device_dialog.py
+++ b/endaqconfig/widgets/device_dialog.py
@@ -3,7 +3,7 @@ Dialog for selecting and/or controlling recording devices.
 
 """
 
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from datetime import datetime, timedelta
 from functools import partial
 import logging
@@ -733,11 +733,12 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
         """
         # TODO: Refactor this!
         tips = []
+        bat = ''
 
         if self.batteryCol is not None:
             bat = self.itemDataMap[index][self.batteryCol]
             if bat:
-                tips.append(bat)
+                bat += '\n'
 
         icon = self.ICON_NONE
         now = datetime.now()
@@ -786,12 +787,15 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
             self.list.SetItemImage(index, [icon])
 
         if len(tips) == 0:
-            self.listToolTips[index] = None
-            self.listMsgs[index] = None
+            self.listToolTips[index] = bat or None
+            self.listMsgs[index] = bat or None
             return
         else:
-            self.listToolTips[index] = '\n'.join(tips)
-            self.listMsgs[index] = '\n'.join([f'\u2022 {s}' for s in tips])
+            # Popup tool tips show battery status and each message on its own
+            # line. In-dialog help message under list shows battery on one,
+            # all other messages on the other.
+            self.listToolTips[index] = bat + '\n'.join(tips)
+            self.listMsgs[index] = bat + ' '.join(tips)
 
 
     def createColumns(self):


### PR DESCRIPTION
This addresses the most important visual tweaks: 
* Formatting of messages under the device list fixed
* 'Start Recording' in list view hidden if device can't record on command
* 'Start Recording' in list view is disabled if the device is in the 'uploading' state
* 'Start Recording' in main dialog is hidden (may be repurposed and restored in the future)

Note: This requires the latest version of [endaq-device](https://github.com/MideTechnology/endaq-device)!