### PR TITLE
ES-728 Fw3.1 config fix

### DIFF
--- a/endaqconfig/config_dialog.py
+++ b/endaqconfig/config_dialog.py
@@ -107,6 +107,16 @@ class ConfigDialog(SC.SizedDialog):
             # Typically, this won't happen outside of testing.
             devName = "Recorder"
 
+        try:
+            # HACK: Force the config interface to load data. This really
+            # shouldn't be necessary, but this is a bit of a special case.
+            # This will probably get fixed in `endaq.device`.
+            self.device.config.configUi = None
+            _ = self.device.config.items
+        except AttributeError as err:
+            # Typically, this won't happen outside of testing, either.
+            logger.debug(f'AttributeError forcing config to load: {err}')
+
         kwargs.setdefault("title", f"Configure {devName}")
         kwargs.setdefault("style", wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
 


### PR DESCRIPTION
With the `UserDeviceName` taken from `DEVINFO`, the config interface wasn't fully loaded when the dialog populated. This prevented the dialog from populating, and also prevented changes from saving (CONFIG.UI wasn't cached, so there were no ConfigIDs to write).

This PR adds a hack to force CONFIG.UI and config.cfg loading. A better fix should be done in `endaq.device` itself, but this work-around won't be broken by it.