### PR TITLE
Release/2.0.2

### DIFF
--- a/endaqconfig/__init__.py
+++ b/endaqconfig/__init__.py
@@ -3,7 +3,7 @@ A GUI for configuring enDAQ data recoders. This can be run standalone, or
 imported into another script.
 """
 
-__version__ = "2.0.2b1"
+__version__ = "2.0.2"
 
 import logging
 

--- a/endaqconfig/__init__.py
+++ b/endaqconfig/__init__.py
@@ -3,7 +3,7 @@ A GUI for configuring enDAQ data recoders. This can be run standalone, or
 imported into another script.
 """
 
-__version__ = "2.0.1"
+__version__ = "2.0.2b1"
 
 import logging
 

--- a/endaqconfig/base.py
+++ b/endaqconfig/base.py
@@ -688,7 +688,7 @@ class ConfigWidget(wx.Panel, ConfigBase):
     def setToDefault(self, check=False):
         """ Reset the Field to its default value.
         """
-        super(ConfigWidget, self).setToDefault()
+        super(ConfigWidget, self).setToDefault(check=check)
         self.setCheck(check)
 
 

--- a/endaqconfig/config_dialog.py
+++ b/endaqconfig/config_dialog.py
@@ -242,7 +242,7 @@ class ConfigDialog(SC.SizedDialog):
         self.hints = self.device.config.getConfigUI()
 
 
-    def applyConfigData(self, data: Dict[int, Any], reset: bool = False):
+    def applyConfigData(self, data: Dict[int, Any], reset: bool = True):
         """ Apply a dictionary of configuration data to the UI.
 
             :param data: The dictionary of config values, keyed by ConfigID.
@@ -408,7 +408,10 @@ class ConfigDialog(SC.SizedDialog):
         with wx.FileDialog(self, message="Export Device Configuration",
                            style=wx.FD_OPEN, wildcard=wildcard) as dlg:
             if dlg.ShowModal() == wx.ID_OK:
-                configio.importConfig(self.device, dlg.GetPath())
+                configio.importConfig(self.device, dlg.GetPath(),
+                                      exclude=(0x8ff7f, 0x9ff7f,  # name, notes
+                                               0x18ff7f, 0x19ff7f, 0x1aff7f,  # wi-fi stuff
+                                               0x28ff7f, 0x29ff7f, 0x2aff7f))
                 self.loadConfigData()
 
 
@@ -428,7 +431,7 @@ class ConfigDialog(SC.SizedDialog):
                 try:
                     self.updateConfigData()
                     self.updateDeviceConfig()
-                    configio.exportConfig(self.device, dlg.GetPath())
+                    configio.exportConfig(self.device, dlg.GetPath(), unknown=True)
 
                 except ConfigError as err:
                     self.showError(str(err), "Configuration Export Failed",


### PR DESCRIPTION
Fixes issue with imported configuration data merging into, rather than replacing, existing values. Goes with changes in `endaq-device` 1.3.2.