### PR TITLE
Another datetime compatibility fix

### DIFF
--- a/endaqconfig/widgets/device_dialog.py
+++ b/endaqconfig/widgets/device_dialog.py
@@ -783,7 +783,6 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
             if lifeleft.days < 0:
                 icon = max(icon, self.ICON_WARN)
 
-        print(f'{now=!r} {calExp=!r}')
         if calExp:
             if calExp < now:
                 tips.append(f"This device's calibration has expired on {calExp.date()}.")

--- a/endaqconfig/widgets/device_dialog.py
+++ b/endaqconfig/widgets/device_dialog.py
@@ -746,20 +746,20 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
                 bat += '\n'
 
         icon = self.ICON_NONE
-        try:
-            now = datetime.datetime.now(datetime.UTC)
-        except AttributeError:
-            # TODO: Remove after Python 3.9 is dropped;
-            #  it doesn't have datetime.UTC!
-            now = datetime.datetime.utcnow()
+
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         if dev.birthday:
-            age = now - dev.birthday
+            # HACK: datetime values differed at least 3 times between Python
+            #  versions 3.9 and 3.12+; make explicitly sure we're using UTC.
+            age = now - dev.birthday.replace(tzinfo=datetime.timezone.utc)
             lifeleft = dev.LIFESPAN - age
         else:
             age = lifeleft = None
 
         calExp = dev.getCalExpiration()
+        if calExp:
+            calExp = calExp.replace(tzinfo=datetime.timezone.utc)
 
         pathtext = dev.path
         if dev.path and os.path.exists(dev.path):
@@ -783,6 +783,7 @@ class DeviceSelectionDialog(sc.SizedDialog, listmix.ColumnSorterMixin):
             if lifeleft.days < 0:
                 icon = max(icon, self.ICON_WARN)
 
+        print(f'{now=!r} {calExp=!r}')
         if calExp:
             if calExp < now:
                 tips.append(f"This device's calibration has expired on {calExp.date()}.")


### PR DESCRIPTION
Made *sure* `datetime` are UTC (not consistent when run in Python 3.9-3.13) by explicitly adding time zone info